### PR TITLE
Use tail instead of head

### DIFF
--- a/files/run.sh
+++ b/files/run.sh
@@ -21,7 +21,7 @@ until ara-manage migrate; do
     sleep 10
 done
 
-result=$(echo "from django.contrib.auth import get_user_model; User = get_user_model(); print(User.objects.filter(username='$ARA_API_USERNAME').count()>0)" | ara-manage shell | head -n 1)
+result=$(echo "from django.contrib.auth import get_user_model; User = get_user_model(); print(User.objects.filter(username='$ARA_API_USERNAME').count()>0)" | ara-manage shell | tail -n 1)
 if [ $result == "False" ]; then
     echo "from django.contrib.auth.models import User; User.objects.create_superuser('$ARA_API_USERNAME', '$ARA_API_USERNAME@ara-server.local', '$ARA_API_PASSWORD')" | ara-manage shell
 fi


### PR DESCRIPTION
ARA 1.4.0 prints an additional line ([ara] Using settings file: /home/ara-server/.ara/server/settings.yaml)
when called.